### PR TITLE
Use CFLAGS passed to the configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,4 +34,6 @@ if test "x$ZLIB_HEADER" = "x"; then
    AC_MSG_ERROR([zlib header file "zlib.h" was not found])
 fi
 
+AC_CONFIG_FILES([rebar.config])
+
 AC_OUTPUT

--- a/rebar.config.in
+++ b/rebar.config.in
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{port_env, [{"CFLAGS", "-g -O2 -Wall"}]}.
+{port_env, [{"CFLAGS", "-g -O2 -Wall @CFLAGS@"}]}.
 
 {port_specs, [{"priv/lib/ezlib_drv.so", ["c_src/ezlib_drv.c"]}]}.
 


### PR DESCRIPTION
This is also useful to support per-package staging directory within
buildroot.

Signed-off-by: Fabio Porcedda <fabio.porcedda@gmail.com>