### PR TITLE
Link with libz during the build.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {erl_opts, [debug_info]}.
 
-{port_env, [{"CFLAGS", "-g -O2 -Wall"}]}.
+{port_env, [{"CFLAGS", "-g -O2 -Wall"},
+            {"LDFLAGS","$LDFLAGS -lz"}]}.
 
 {port_specs, [{"priv/lib/ezlib_drv.so", ["c_src/ezlib_drv.c"]}]}.
 


### PR DESCRIPTION
Without this patch, there were undefined referenced to libz symbols
as shown by ldd -r on the resulting shared object.
